### PR TITLE
remove version string from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ To apply this plugin:
 ```groovy
 buildscript { repositories { jcenter() } }
 plugins {
-  id 'nebula.lint' version '7.4.0'
+  id 'nebula.lint' version 'x.x.x'  // set version here
 }
 ```
-    
+See (releases page](https://github.com/nebula-plugins/gradle-lint-plugin/releases) for available versions.
+
 *Important:* For now, in a multi-module build you **must** apply lint to the root project, at a minimum.
 
 Alternatively:


### PR DESCRIPTION
The instructions used version `7.4.0` in the example, which was a pitfall as a first time user when things were not working.

Instead, use a `x.x.x` version placeholder and refer reader to a page where they can choose a correct version.